### PR TITLE
Changing a string to key:value pair to fix flakiness in `testSerializationWithDefaults`

### DIFF
--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3DataSegmentPusherConfigTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3DataSegmentPusherConfigTest.java
@@ -29,7 +29,6 @@ import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
 import javax.validation.Validator;
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -44,11 +43,7 @@ public class S3DataSegmentPusherConfigTest
                         + "\"disableAcl\":false,\"maxListingLength\":2000,\"useS3aSchema\":false}";
 
     S3DataSegmentPusherConfig config = JSON_MAPPER.readValue(jsonConfig, S3DataSegmentPusherConfig.class);
-
-    HashMap<String, String> expected = JSON_MAPPER.readValue(jsonConfig, HashMap.class);
-    HashMap<String, String> actual = JSON_MAPPER.readValue(JSON_MAPPER.writeValueAsString(config), HashMap.class);
-
-    Assert.assertEquals(expected, actual);
+    Assert.assertEquals(jsonConfig, JSON_MAPPER.writeValueAsString(config));
   }
 
   @Test

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3DataSegmentPusherConfigTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3DataSegmentPusherConfigTest.java
@@ -29,8 +29,8 @@ import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
 import javax.validation.Validator;
 import java.io.IOException;
+import java.util.LinkedHashMap;
 import java.util.Set;
-import java.util.TreeMap;
 
 public class S3DataSegmentPusherConfigTest
 {
@@ -44,8 +44,8 @@ public class S3DataSegmentPusherConfigTest
 
     S3DataSegmentPusherConfig config = JSON_MAPPER.readValue(jsonConfig, S3DataSegmentPusherConfig.class);
 
-    TreeMap<String, String> expected = JSON_MAPPER.readValue(jsonConfig, TreeMap.class);
-    TreeMap<String, String> actual = JSON_MAPPER.readValue(JSON_MAPPER.writeValueAsString(config), TreeMap.class);
+    LinkedHashMap<String, String> expected = JSON_MAPPER.readValue(jsonConfig, LinkedHashMap.class);
+    LinkedHashMap<String, String> actual = JSON_MAPPER.readValue(JSON_MAPPER.writeValueAsString(config), LinkedHashMap.class);
 
     Assert.assertEquals(expected, actual);
   }

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3DataSegmentPusherConfigTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3DataSegmentPusherConfigTest.java
@@ -30,6 +30,7 @@ import javax.validation.Validation;
 import javax.validation.Validator;
 import java.io.IOException;
 import java.util.Set;
+import java.util.TreeMap;
 
 public class S3DataSegmentPusherConfigTest
 {
@@ -42,7 +43,11 @@ public class S3DataSegmentPusherConfigTest
                         + "\"disableAcl\":false,\"maxListingLength\":2000,\"useS3aSchema\":false}";
 
     S3DataSegmentPusherConfig config = JSON_MAPPER.readValue(jsonConfig, S3DataSegmentPusherConfig.class);
-    Assert.assertEquals(jsonConfig, JSON_MAPPER.writeValueAsString(config));
+
+    TreeMap<String, String> expected = JSON_MAPPER.readValue(jsonConfig, TreeMap.class);
+    TreeMap<String, String> actual = JSON_MAPPER.readValue(JSON_MAPPER.writeValueAsString(config), TreeMap.class);
+
+    Assert.assertEquals(expected, actual);
   }
 
   @Test

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3DataSegmentPusherConfigTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3DataSegmentPusherConfigTest.java
@@ -30,6 +30,7 @@ import javax.validation.Validation;
 import javax.validation.Validator;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 public class S3DataSegmentPusherConfigTest
@@ -56,9 +57,10 @@ public class S3DataSegmentPusherConfigTest
     String jsonConfig = "{\"bucket\":\"bucket1\",\"baseKey\":\"dataSource1\"}";
     String expectedJsonConfig = "{\"bucket\":\"bucket1\",\"baseKey\":\"dataSource1\","
                                 + "\"disableAcl\":false,\"maxListingLength\":1024,\"useS3aSchema\":false}";
-
     S3DataSegmentPusherConfig config = JSON_MAPPER.readValue(jsonConfig, S3DataSegmentPusherConfig.class);
-    Assert.assertEquals(expectedJsonConfig, JSON_MAPPER.writeValueAsString(config));
+    Map<String, String> expected = JSON_MAPPER.readValue(expectedJsonConfig, Map.class);
+    Map<String, String> actual = JSON_MAPPER.readValue(JSON_MAPPER.writeValueAsString(config), Map.class);
+    Assert.assertEquals(expected, actual);
   }
 
   @Test

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3DataSegmentPusherConfigTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3DataSegmentPusherConfigTest.java
@@ -29,7 +29,7 @@ import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
 import javax.validation.Validator;
 import java.io.IOException;
-import java.util.LinkedHashMap;
+import java.util.HashMap;
 import java.util.Set;
 
 public class S3DataSegmentPusherConfigTest
@@ -44,8 +44,8 @@ public class S3DataSegmentPusherConfigTest
 
     S3DataSegmentPusherConfig config = JSON_MAPPER.readValue(jsonConfig, S3DataSegmentPusherConfig.class);
 
-    LinkedHashMap<String, String> expected = JSON_MAPPER.readValue(jsonConfig, LinkedHashMap.class);
-    LinkedHashMap<String, String> actual = JSON_MAPPER.readValue(JSON_MAPPER.writeValueAsString(config), LinkedHashMap.class);
+    HashMap<String, String> expected = JSON_MAPPER.readValue(jsonConfig, HashMap.class);
+    HashMap<String, String> actual = JSON_MAPPER.readValue(JSON_MAPPER.writeValueAsString(config), HashMap.class);
 
     Assert.assertEquals(expected, actual);
   }


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

In this PR, I am proposing a fix for a flaky test identified in `org.apache.druid.storage.s3.S3DataSegmentPusherConfigTest.testSerializationWithDefaults`.

<!-- Describe the goal of this PR, and what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

The mentioned test compares two strings. An `ObjectMapper` variable is being leveraged to carry out the serialization and deserialization process. The serialization process internally leverages a `getDeclaredFields()` function. As per [Javadoc](https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#getDeclaredFields--),
> The elements in the returned array are not sorted and are not in any particular order.

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->
In order to overcome this problem,  I am proposing to use a Map to serialize the strings before they are compared. The usage of Map before the comparison occurs shifts the focus of validation to evaluating the key-value pairs rather than the order in which they are serialized.
<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

Patch that I have developed:

https://github.com/krishnanand5/druid/pull/2/commits/2a6cf8be285911990ff257de075a9ecb59a864f7

Steps to verify the patch:

1. `https://github.com/apache/druid.git`.
2. `mvn install -pl extensions-core/s3-extensions -am -DskipTests`.
3. `mvn -pl extensions-core/s3-extensions test -Dtest=S3DataSegmentPusherConfigTest#testSerializationWithDefaults`.
4. `mvn -pl extensions-core/s3-extensions edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=S3DataSegmentPusherConfigTest#testSerializationWithDefaults`.
5. To further verify the reliability of the fix, we can set nondex runs to 100 - `mvn -pl extensions-core/s3-extensions edu.illinois:nondex-maven-plugin:2.1.1:nondex -DnondexRuns=100 -Dtest=S3DataSegmentPusherConfigTest#testSerializationWithDefaults`.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end-user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->

Addressed a minor flakiness that was observed in `testSerializationWithDefaults`.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
