### PR TITLE
Addressing 5 flaky tests in `org.apache.druid.math.expr.ParserTest`

### DIFF
--- a/processing/src/test/java/org/apache/druid/math/expr/ParserTest.java
+++ b/processing/src/test/java/org/apache/druid/math/expr/ParserTest.java
@@ -38,6 +38,7 @@ import org.junit.rules.ExpectedException;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -820,7 +821,7 @@ public class ParserTest extends InitializedNullHandlingTest
     }
     final Expr.BindingAnalysis deets = parsed.analyzeInputs();
     Assert.assertEquals(expression, expected, parsed.toString());
-    Assert.assertEquals(expression, identifiers, deets.getRequiredBindingsList());
+    Assert.assertEquals(expression, new HashSet<>(identifiers), deets.getRequiredBindings());
     Assert.assertEquals(expression, scalars, deets.getScalarVariables());
     Assert.assertEquals(expression, arrays, deets.getArrayVariables());
 
@@ -828,7 +829,7 @@ public class ParserTest extends InitializedNullHandlingTest
     final Expr roundTrip = Parser.parse(parsedNoFlatten.stringify(), ExprMacroTable.nil());
     Assert.assertEquals(parsed.stringify(), roundTrip.stringify());
     final Expr.BindingAnalysis roundTripDeets = roundTrip.analyzeInputs();
-    Assert.assertEquals(expression, identifiers, roundTripDeets.getRequiredBindingsList());
+    Assert.assertEquals(expression, new HashSet<>(identifiers), roundTripDeets.getRequiredBindings());
     Assert.assertEquals(expression, scalars, roundTripDeets.getScalarVariables());
     Assert.assertEquals(expression, arrays, roundTripDeets.getArrayVariables());
   }


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

In this PR, I am proposing a fix to address four flaky tests in found `org.apache.druid.math.expr.ParserTest`. They are:

- `org.apache.druid.math.expr.ParserTest.testSimpleLogicalOps1`
- `org.apache.druid.math.expr.ParserTest.testSimpleAdditivityOp1`
- `org.apache.druid.math.expr.ParserTest.testSimpleAdditivityOp2`
- `org.apache.druid.math.expr.ParserTest.testApplyFunctions`
- `org.apache.druid.math.expr.ParserTest.testSimpleMultiplicativeOp1`

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

The mentioned tests compare a respective arithmetic operation with their prefix equivalents. When the prefix equivalent is generated, the generated prefix is sent back to the assertion in the form of a list. When doing a bare string comparison with the returned list, the order of characters is not maintained and this introduces a degree of flakiness. 

I verified the flaky behavior of these tests with a tool called [NonDex](https://github.com/TestingResearchIllinois/NonDex). One of the stack-traces generated when I executed index against one of the affected tests has been included below for your reference.

```
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 1.693 s <<< FAILURE! -- in org.apache.druid.math.expr.ParserTest
[ERROR] org.apache.druid.math.expr.ParserTest.testSimpleMultiplicativeOp1 -- Time elapsed: 0 s <<< FAILURE!
java.lang.AssertionError: x*y expected:<[x, y]> but was:<[y, x]>
	at org.junit.Assert.fail(Assert.java:89)
	at org.junit.Assert.failNotEquals(Assert.java:835)
	at org.junit.Assert.assertEquals(Assert.java:120)
	at org.apache.druid.math.expr.ParserTest.validateParser(ParserTest.java:823)
	at org.apache.druid.math.expr.ParserTest.validateParser(ParserTest.java:799)
	at org.apache.druid.math.expr.ParserTest.testSimpleMultiplicativeOp1(ParserTest.java:197)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.rules.ExpectedException$ExpectedExceptionStatement.evaluate(ExpectedException.java:258)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.junit.runners.Suite.runChild(Suite.java:128)
	at org.junit.runners.Suite.runChild(Suite.java:27)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.apache.maven.surefire.junitcore.JUnitCore.run(JUnitCore.java:49)
	at org.apache.maven.surefire.junitcore.JUnitCoreWrapper.createRequestAndRun(JUnitCoreWrapper.java:120)
	at org.apache.maven.surefire.junitcore.JUnitCoreWrapper.executeEager(JUnitCoreWrapper.java:95)
	at org.apache.maven.surefire.junitcore.JUnitCoreWrapper.execute(JUnitCoreWrapper.java:75)
	at org.apache.maven.surefire.junitcore.JUnitCoreWrapper.execute(JUnitCoreWrapper.java:64)
	at org.apache.maven.surefire.junitcore.JUnitCoreProvider.invoke(JUnitCoreProvider.java:163)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:385)
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
	at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:507)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:495)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR] org.apache.druid.math.expr.ParserTest.testSimpleMultiplicativeOp1
[ERROR]   Run 1: ParserTest.testSimpleMultiplicativeOp1:198->validateParser:799->validateParser:823 x/y expected:<[x, y]> but was:<[y, x]>
[ERROR]   Run 2: ParserTest.testSimpleMultiplicativeOp1:197->validateParser:799->validateParser:823 x*y expected:<[x, y]> but was:<[y, x]>
[ERROR]   Run 3: ParserTest.testSimpleMultiplicativeOp1:197->validateParser:799->validateParser:823 x*y expected:<[x, y]> but was:<[y, x]>
[ERROR]   Run 4: ParserTest.testSimpleMultiplicativeOp1:197->validateParser:799->validateParser:823 x*y expected:<[x, y]> but was:<[y, x]>
[INFO] 
[INFO] 
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
[INFO] 
```

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

- To overcome the above-mentioned problem, I am proposing a change using another equivalent function that exists within `Expr.Java` which is `getRequiredBindings()`. 
- This function returns the prefix-converted string in the form of a set. 
- However, if we are concerned with only the elements that are returned after prefix conversion and not the actual order, we can convert the expected string and the received string into a HashSet<> and perform the comparison. 
- This ensures that we only check the components of the string and not the actual order.

To evaluate the correctness of the proposed fix, following commands can be executed with the NonDex tool:
Steps to verify the patch:

1. `https://github.com/apache/druid.git`.
2. `mvn install -pl processing -am -DskipTests`.
3. `mvn -pl processing test -Dtest=org.apache.druid.math.expr.ParserTest#testSimpleLogicalOps1` 
4. `mvn -pl processing edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.druid.math.expr.ParserTest#testSimpleLogicalOps1` 
5. To further verify the reliability of the fix, we can set nondex runs to 100 
`mvn -pl processing edu.illinois:nondex-maven-plugin:2.1.1:nondex -DnondexRuns=100 -Dtest=org.apache.druid.math.expr.ParserTest#testSimpleLogicalOps1`

The same procedure can be executed to verify the status of the other 4 tests.

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->

Addressed Flakiness in certain tests of `org.apache.druid.math.expr.ParserTest`.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
