### PR TITLE
Addressing 2 Flaky Tests in `ProtobufInputFormatTest`

### DIFF
--- a/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/ProtobufInputFormatTest.java
+++ b/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/ProtobufInputFormatTest.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.io.Files;
 import org.apache.druid.common.config.NullHandling;
@@ -57,6 +58,7 @@ import org.junit.rules.ExpectedException;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.HashSet;
 
 public class ProtobufInputFormatTest
 {
@@ -231,7 +233,7 @@ public class ProtobufInputFormatTest
     ).read().next();
 
     Assert.assertEquals(
-        ImmutableList.builder()
+        ImmutableSet.builder()
                      .add("eventType")
                      .add("foobar")
                      .add("bar0")
@@ -244,7 +246,7 @@ public class ProtobufInputFormatTest
                      .add("id")
                      .add("someBytesColumn")
                      .build(),
-        row.getDimensions()
+        new HashSet<>(row.getDimensions())
     );
 
     ProtobufInputRowParserTest.verifyNestedData(row, dateTime);
@@ -368,7 +370,7 @@ public class ProtobufInputFormatTest
     InputRow row = transformingReader.read().next();
 
     Assert.assertEquals(
-        ImmutableList.of(
+        ImmutableSet.of(
             "someOtherId",
             "someIntColumn",
             "isValid",
@@ -381,7 +383,7 @@ public class ProtobufInputFormatTest
             "id",
             "someBytesColumn"
         ),
-        row.getDimensions()
+        new HashSet<>(row.getDimensions())
     );
 
     Assert.assertEquals(ImmutableMap.of("bar", "baz"), row.getRaw("foo"));


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

This PR is intended to address two flaky tests detected in :
- `org.apache.druid.data.input.protobuf.ProtobufInputFormatTest.testParseNestedDataSchemaless`.
- `org.apache.druid.data.input.protobuf.ProtobufInputFormatTest.testParseFlattenDataDiscover`.


<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->
### Goal of the PR:
The findings apply to both identified tests:
- The dimensions of `row` are converted to set from list internally.
- The order of dimensions in `row` is being changed by internal executions.
- When comparing the dimensions of `row` with an immutable list of dimensions, a flaky error can arise if the order of dimensions in `row` is changed unintentionally during transit.

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->
### Patch Description:
- The fix involves comparing the dimensions of row with an `ImmutableSet`.
- The dimensions of row are converted to a HashSet().
- This change enables to perform the assertion on the presence of elements rather than the actual order.
<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->
I used the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool to confim the flakiness. 

### Steps to reproduce the issue with Nondex:

1. `mvn -pl extensions-core/protobuf-extensions edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.druid.data.input.protobuf.ProtobufInputFormatTest#testParseFlattenDataDiscover`. 
```
[ERROR] Failures: 
[ERROR] org.apache.druid.data.input.protobuf.ProtobufInputFormatTest.testParseFlattenDataDiscover
[ERROR]   Run 1: ProtobufInputFormatTest.testParseFlattenDataDiscover:233 expected:<[eventType, foobar, bar0, someOtherId, someIntColumn, isValid, description, someLongColumn, someFloatColumn, id, someBytesColumn]> but was:<[eventType, foobar, bar0, someOtherId, isValid, id, description, someBytesColumn, someIntColumn, someFloatColumn, someLongColumn]>
[ERROR]   Run 2: ProtobufInputFormatTest.testParseFlattenDataDiscover:233 expected:<[eventType, foobar, bar0, someOtherId, someIntColumn, isValid, description, someLongColumn, someFloatColumn, id, someBytesColumn]> but was:<[eventType, foobar, bar0, someFloatColumn, someOtherId, isValid, description, id, someBytesColumn, someIntColumn, someLongColumn]>
[ERROR]   Run 3: ProtobufInputFormatTest.testParseFlattenDataDiscover:233 expected:<[eventType, foobar, bar0, someOtherId, someIntColumn, isValid, description, someLongColumn, someFloatColumn, id, someBytesColumn]> but was:<[eventType, foobar, bar0, someOtherId, isValid, someBytesColumn, id, description, someLongColumn, someIntColumn, someFloatColumn]>
[ERROR]   Run 4: ProtobufInputFormatTest.testParseFlattenDataDiscover:233 expected:<[eventType, foobar, bar0, someOtherId, someIntColumn, isValid, description, someLongColumn, someFloatColumn, id, someBytesColumn]> but was:<[eventType, foobar, bar0, someIntColumn, someFloatColumn, someBytesColumn, isValid, description, id, someLongColumn, someOtherId]>
[INFO] 
[INFO] 
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
```
(or) 
`mvn -pl extensions-core/protobuf-extensions edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.druid.data.input.protobuf.ProtobufInputFormatTest#testParseNestedDataSchemaless`.
```
[ERROR] Failures: 
[ERROR] org.apache.druid.data.input.protobuf.ProtobufInputFormatTest.testParseNestedDataSchemaless
[ERROR]   Run 1: ProtobufInputFormatTest.testParseNestedDataSchemaless:370 expected:<[someOtherId, someIntColumn, isValid, foo, description, someLongColumn, someFloatColumn, eventType, bar, id, someBytesColumn]> but was:<[bar, someFloatColumn, someBytesColumn, isValid, description, someLongColumn, someOtherId, someIntColumn, eventType, foo, id]>
[ERROR]   Run 2: ProtobufInputFormatTest.testParseNestedDataSchemaless:370 expected:<[someOtherId, someIntColumn, isValid, foo, description, someLongColumn, someFloatColumn, eventType, bar, id, someBytesColumn]> but was:<[someLongColumn, bar, someFloatColumn, isValid, eventType, id, description, foo, someOtherId, someBytesColumn, someIntColumn]>
[ERROR]   Run 3: ProtobufInputFormatTest.testParseNestedDataSchemaless:370 expected:<[someOtherId, someIntColumn, isValid, foo, description, someLongColumn, someFloatColumn, eventType, bar, id, someBytesColumn]> but was:<[someFloatColumn, isValid, id, description, someOtherId, eventType, someBytesColumn, someLongColumn, bar, foo, someIntColumn]>
[ERROR]   Run 4: ProtobufInputFormatTest.testParseNestedDataSchemaless:370 expected:<[someOtherId, someIntColumn, isValid, foo, description, someLongColumn, someFloatColumn, eventType, bar, id, someBytesColumn]> but was:<[bar, foo, description, id, someBytesColumn, someIntColumn, someOtherId, someFloatColumn, someLongColumn, isValid, eventType]>
[INFO] 
[INFO] 
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
```
2. The applied patch has been tested by setting NonDexRuns to 100 in order to test the resiliency of the change across multiple seeds.

<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->
Addressed minor flakiness observed in `ProtobufInputFormatTest`.
<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [X] been self-reviewed.
- [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [X] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.